### PR TITLE
Remove reference to missing function '_protobuf_find_threads'

### DIFF
--- a/cmake/protobuf-module.cmake.in
+++ b/cmake/protobuf-module.cmake.in
@@ -133,10 +133,6 @@ _protobuf_find_libraries(Protobuf_PROTOC protoc)
 
 endif()
 
-if(UNIX)
-  _protobuf_find_threads()
-endif()
-
 # Set the include directory
 get_target_property(Protobuf_INCLUDE_DIRS protobuf::libprotobuf
   INTERFACE_INCLUDE_DIRECTORIES)


### PR DESCRIPTION
Hi @rbsheth, tried using 3.19.4-p0 today and it was failing to build. Looks like the cherry pick [here](https://github.com/cpp-pm/protobuf/commit/dbf6c69acb19017f3e4166d80ac0045a0d3c6514) added an obsolete call to _protobuf_find_threads.